### PR TITLE
removed unnecessary myst-parser extensions from conf.py

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -53,18 +53,8 @@ templates_path = ['_templates']
 source_suffix = ['.rst', '.md']
 
 myst_enable_extensions = [
-    "amsmath",
     "colon_fence",
-    "deflist",
-    "dollarmath",
-    "fieldlist",
     "html_admonition",
-    "html_image",
-    "replacements",
-    "smartquotes",
-    "strikethrough",
-    "substitution",
-    "tasklist",
 ]
 
 hoverxref_roles = [


### PR DESCRIPTION
As discussed, I removed all unnecessary myst-parser extensions from the conf.py file.
